### PR TITLE
glib.h: add GDestroyNotify function ptr type.

### DIFF
--- a/include/glib.h
+++ b/include/glib.h
@@ -75,6 +75,7 @@ static inline void g_boxed() {}
 typedef gpointer (*GBoxedCopyFunc)(gpointer s);
 typedef void (*GBoxedFreeFunc)(gpointer s);
 typedef void (*GFunc)(gpointer data, gpointer user_data);
+typedef void (*GDestroyNotify)(gpointer data);
 
 #include "glib-string.h"
 #include "glib-list.h"


### PR DESCRIPTION
Is needed for vala-generated _vala_array_destroy and _vala_array_free functions.
